### PR TITLE
Set "endOfLine" to auto in prettier config

### DIFF
--- a/packages/prettier-config/index.js
+++ b/packages/prettier-config/index.js
@@ -4,5 +4,6 @@ module.exports = {
     singleQuote: false,
     quoteProps: "consistent",
     trailingComma: "es5",
+    endOfLine: "auto",
     printWidth: 80,
 };


### PR DESCRIPTION
Prettier by default uses `LF` but when working on a cross-platform repo where we let git handle the CRLF <> LF conversions for us. This default behavior causes Prettier and Git to start battling with each other and causes lint checks to fail. By setting it to auto, Prettier will respect the line endings that exist on the file and not change them.